### PR TITLE
This PR fixes that starting a combat with the 'Create Encounter' butt…

### DIFF
--- a/scripts/spellTemplateManager.js
+++ b/scripts/spellTemplateManager.js
@@ -368,16 +368,18 @@ class spellTemplateManager {
 		}
 	}
 
-	static async updateCombat(Combat){
-		await spellTemplateManager.ageTemplates(Combat);
-		await spellTemplateManager.cleanupTemplates(Combat);
-		
+	static async updateCombat(Combat) {
+		if (Combat.combatant) {
+			await spellTemplateManager.ageTemplates(Combat);
+			await spellTemplateManager.cleanupTemplates(Combat);
+		}
 	}
 
 	static async preUpdateCombat(Combat, userID=''){
-		await spellTemplateManager.cleanupTemplates(Combat);
-		await spellTemplateManager.manageUnmanaged(Combat,(userID?true:false));
-
+		if (Combat.combatant) {
+			await spellTemplateManager.cleanupTemplates(Combat);
+			await spellTemplateManager.manageUnmanaged(Combat, (userID ? true : false));
+		}
 	}
 
 	static resetTemplateBorders(){


### PR DESCRIPTION
…on on the 'Combat Tracker' gets one the following exceptions due to there not being any combatants:

```
spellTemplateManager.js:167 Uncaught (in promise) TypeError: Cannot read property 'actor' of undefined
    at Function.cleanupTemplates (spellTemplateManager.js:167)
    at Function.preUpdateCombat (spellTemplateManager.js:378)
    at spellTemplateManager.js:557
    at Function._call (foundry.js:2496)
    ...

spellTemplateManager.js:303 Uncaught (in promise) TypeError: Cannot read property 'actor' of undefined
    at Function.ageTemplates (spellTemplateManager.js:303)
    at Function.updateCombat (spellTemplateManager.js:372)
    at spellTemplateManager.js:567
    ...
```